### PR TITLE
feat: Page/home과 Page/setting 연결

### DIFF
--- a/CaffeineDrop/components/GNB.jsx
+++ b/CaffeineDrop/components/GNB.jsx
@@ -20,7 +20,7 @@ const GNB = () => {
         <TouchableOpacity onPress={() => navigation.navigate('SearchPage')}>
           <SearchIcon width={responsiveWidth(24)} height={responsiveHeight(24)} />
         </TouchableOpacity>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => navigation.navigate('SettingPage01')}>
           <MypageIcon width={responsiveWidth(24)} height={responsiveHeight(24)} />
         </TouchableOpacity>
       </Icons>


### PR DESCRIPTION
### 📝 Summary
- 홈 페이지와 설정 페이지 연결
- 오른쪽 상단의 마이페이지 아이콘 클릭 시 설정 페이지로 연결

### 🛠 PR Type
- [x] **Feature**
- [ ] **Bugfix**
- [ ] **Refactoring**
- [ ] **Code style changes** (formatting, variable name, comments)
- [ ] **Documentation content changes**
- [ ] **Test related changes**
- [ ] **Build related changes**
- [ ] **Delete or rename a file or folder**
- [ ] **Other:** [내용을 적어주세요]

### ✅ Checklist
- [x] 커밋 메시지 규칙을 따랐는지
- [x] 변경 사항에 대해 테스트가 완료되었는지

### 📸 Screen Shot(optional)

https://github.com/user-attachments/assets/d33b8024-ddfe-440f-9363-00f676f1a461

### 📝 Notes (optional)
- 설정페이지 내부에서의 연결은 아직 이루어지지 않아 추후 수정 필요
- Page/setting 브랜치에서 ListInnerBox를 TouchableOpacity로 변경해서 코드 수정하면 될 듯함